### PR TITLE
Disable cassandra from starting with default config

### DIFF
--- a/files/policy-rc.d
+++ b/files/policy-rc.d
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [ "${1}" = "--quiet" ]; then
+  name="$2"
+else
+  name="$1"
+fi
+sensitive_services_list=/etc/sensitive_services
+grep -x "$name" "$sensitive_services_list" && exit 101
+exit 0

--- a/tasks/install/debian.yml
+++ b/tasks/install/debian.yml
@@ -1,4 +1,7 @@
 ---
+- name: install policy-rc.d to selectively disable automated service start by apt
+  copy: src=policy-rc.d dest=/usr/sbin/policy-rc.d mode=0755
+
 - name: Install curl
   apt: name=curl state=installed
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,9 +4,18 @@
   when: ansible_os_family == 'Debian' and cassandra_manage_repo
   tags: [cassandra.install, install, cassandra.repo, repo]
 
+- name: stop cassandra from running with default config
+  lineinfile: dest=/etc/sensitive_services line=cassandra state=present create=yes
+  when: ansible_os_family == 'Debian'
+  tags: [package, cassandra.package, cassandra.install, install]
+
 - include: install/debian.yml
   when: ansible_os_family == 'Debian'
   tags: [package, cassandra.package, cassandra.install, install]
 
 - include: configure.yml
   tags: [configure, cassandra.configure]
+
+- name: Remove cassandra from /etc/sensitive_servies to enable automated starts
+  lineinfile: dest=/etc/sensitive_services line=cassandra state=absent
+  when: ansible_os_family == 'Debian'


### PR DESCRIPTION
Cassandra need to be configured before it start, so added steps to
disable apt to start it during installation.
