### PR TITLE
Enable force-yes in apt

### DIFF
--- a/tasks/install/debian.yml
+++ b/tasks/install/debian.yml
@@ -6,7 +6,7 @@
   apt: name=curl state=installed
 
 - name: Install JRE and other dependencies mentioned as cassandra dependencies
-  apt: pkg={{ item }} state=installed
+  apt: pkg={{ item }} state=installed force=yes
   register: jdk_installed
   with_items: "{{ cassandra_deps }}"
   tags: [deps, cassandra.deps]


### PR DESCRIPTION
sometimes force-yes would be required. One instance I see is when tzdata
needed to be degraded to match jre.