### PR TITLE
Flush handlers within the role

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,3 +25,5 @@
 
 - include: service.yml
   tags: [service, cassandra.service]
+
+- meta: flush_handlers


### PR DESCRIPTION
All configs to be applied and restarted within the role itself, so that
any client configs/service restart after that should not cause any
issues because of cassandra is not ready.